### PR TITLE
Little bugfix. Removed expression in the InitCommand::$tmlplDir definition

### DIFF
--- a/src/Console/Command/InitCommand.php
+++ b/src/Console/Command/InitCommand.php
@@ -52,9 +52,10 @@ class InitCommand extends Command
      ';
     
     /**
+     * Initialized in constructor with dynamic value __DIR__ . '/../../../tmpl'
      * @var string
      */
-    protected $tmplDir = __DIR__ . '/../../../tmpl';
+    protected $tmplDir;
     /**
      * @var string
      */
@@ -63,6 +64,15 @@ class InitCommand extends Command
      * @var QuestionHelper $question
      */
     protected $questionHelper;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($name = null)
+    {
+        parent::__construct($name);
+        $this->tmplDir = __DIR__ . '/../../../tmpl';
+    }
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Expressions are not allowed in class fields default value definition until 5.6. As composer.json requires php 5.4+, lib need to resolve this requirement. Or just change it on php 5.6+ :)