### PR TITLE
Добавил возможность установить лоадер команд symfony

### DIFF
--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -84,6 +84,14 @@ class Application extends \Symfony\Component\Console\Application
             $this->initializeBitrix();
         }
 
+        if (
+            $this->getConfiguration()
+            && isset($this->getConfiguration()['commandLoader'])
+            && ($this->getConfiguration()['commandLoader'] instanceof \Closure)
+        ) {
+            $this->setCommandLoader($this->getConfiguration()['commandLoader']());
+        }
+
         if ($this->getConfiguration()) {
             foreach ($this->getBitrixCommands() as $bitrixCommand) {
                 $this->add($bitrixCommand);


### PR DESCRIPTION
В версии 3.4 консоли появилась возможность устанавливать лоадер команд https://symfony.com/blog/new-in-symfony-3-4-lazy-commands

Я добавил эту возможность в джедая.

Пример:

в /.jedi.php:

```php
<?php

use Symfony\Component\Console\CommandLoader\ContainerCommandLoader;

return [
    'web-dir' => __DIR__ . DIRECTORY_SEPARATOR . 'web',
    'env-dir' => 'environments',
    'useModules' => false,
    'commandLoader' => function () {
        return new ContainerCommandLoader(
            $container, // любой DI-контейнер, реализующий PSR-11
            [
                'app:some-command' => AppSomeCommand::class,
            ]
        );
    },
    'commands' => [
    ],
];

```
AppSomeCommand.php:

```php
<?php

class AppSomeCommand extends BitrixCommand
{

    private $eventManager;
    
    private $someService;
    
    public function __construct(EventManager $eventManager, SomeService $someService)
    {
        parent::__construct();

        $this->eventManager = $eventManager;

        $this->someService = $someService;
    }

}

```

Это даёт нам ленивую загрузку команд и прокидывание зависимостей через конструктор у команд консоли